### PR TITLE
Fix for issue #76

### DIFF
--- a/lib_unix/tray/tray.c
+++ b/lib_unix/tray/tray.c
@@ -239,7 +239,7 @@ BOOL mintrayr_CreateIcon(void *handle, mouseevent_callback_t callback)
     gtk_status_icon_set_from_pixbuf(data->statusIcon, buf);
   }
   else {
-    iconname = gtk_window_get_icon_name(gtkWindow));
+    iconname = gtk_window_get_icon_name(gtkWindow);
     if (iconname) {
       gtk_status_icon_set_from_icon_name(data->statusIcon, iconname);
     }


### PR DESCRIPTION
With thunderbird 11 getting the window's icon (via gtk_window_get_icon) to use as tray icon doesn't work anymore. Instead it seems there's an icon name set (gtk_window_get_icon_name) and setting the icon must then be set that way (gtk_status_icon_set_from_icon_name).
And not setting an icon meant nothing is showed on the tray panel (probably depends on the app used, though)
