### PR TITLE
fixed unreachable code in build.py

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -7,7 +7,6 @@ from zipfile import ZipFile, ZipInfo, ZIP_DEFLATED, ZIP_STORED
 try:
     from cmp_listed_locales import cmp_listed_locales
 except ImportError, ex:
-    raise ex
     from warnings import warn
     warn("cannot compare locales ({})".format(ex))
     def cmp_listed_locales(dirname):


### PR DESCRIPTION
I'm currently looking into helping out for this extension and I stumbled accross this block in the build script which I assume is supposed to help people that don't have the full Mozilla Build Tools installed.
