### PR TITLE
Accommodate preset ids for menu_NewPopup menuitem

### DIFF
--- a/chrome/content/messenger/messageWindow.js
+++ b/chrome/content/messenger/messageWindow.js
@@ -13,20 +13,22 @@ addEventListener(
       document.getElementById("MinTrayR_context"),
       'messenger.watchreader',
       function() {
+        var menu_NewPopup_id = "";
         try {
           // Seamonkey hack
           let n = document.querySelector('#menu_NewPopup menuitem');
           if (n && !n.id)  {
             n.id = 'newNewMsgCmd';
           }
+          menu_NewPopup_id = n.id;
         }
         catch (ex) {
           // no-op
         }
-        this.cloneToMenu('MinTrayR_sep-top', ['newNewMsgCmd'], false);
+        this.cloneToMenu('MinTrayR_sep-top', [menu_NewPopup_id], false);
         this.cloneToMenu('MinTrayR_sep-bottom', ['menu_FileQuitItem'], true);
         document
-          .getElementById('MinTrayR_newNewMsgCmd')
+          .getElementById('MinTrayR_' + menu_NewPopup_id)
           .setAttribute(
             'label',
             this.menu.getAttribute('mintrayr_newmessage')

--- a/chrome/content/messenger/messenger.js
+++ b/chrome/content/messenger/messenger.js
@@ -14,12 +14,14 @@ addEventListener(
       document.getElementById('MinTrayR_context'),
       "messenger.watchmessenger",
       function() {
+        var menu_NewPopup_id = "";
         try {
           // Seamonkey hack
           let n = document.querySelector('#menu_NewPopup menuitem');
           if (n && !n.id)  {
             n.id = 'newNewMsgCmd';
           }
+          menu_NewPopup_id = n.id;
         }
         catch (ex) {
           // no-op
@@ -70,10 +72,10 @@ addEventListener(
           ['titlebar-min'].forEach(hijackButton.bind(null, MinTrayRTryMinimizeWindow));
         })(this);
 
-        this.cloneToMenu('MinTrayR_sep-top', ["newNewMsgCmd", "button-getAllNewMsg", "addressBook"], false);
+        this.cloneToMenu('MinTrayR_sep-top', [menu_NewPopup_id, "button-getAllNewMsg", "addressBook"], false);
         this.cloneToMenu('MinTrayR_sep-bottom', ['menu_FileQuitItem'], true);
         document
-          .getElementById('MinTrayR_newNewMsgCmd')
+          .getElementById('MinTrayR_' + menu_NewPopup_id)
           .setAttribute(
             'label',
             this.menu.getAttribute('mintrayr_newmessage')


### PR DESCRIPTION
Fixes operation of MinTrayR on Thunderbird 38.2.0

The pre-existing code implemented the "seamonkey hack", which would set the
id for the `menu_NewPopup menuitem` to `newNewMsgCmd` if an id didn't
already exist.  It would then use that id (`newNewMsgCmd`) in subsequent
searches.  The trouble is, if the id had already been set, the
subsequent searches would fail unless the existing value was
`newNewMsgCmd`.  In fact, in recent versions of Thunderbird, the
pre-existing id is actually `menu_newNewMsgCmd`, so the searches fail.

The bug in the existing code gives rise to the following startup errors:
1.  Error: Failed to clone newNewMsgCmd
    Source File: resource://mintrayr/mintrayr.jsm
    Line: 124
2.  Error: TypeError: document.getElementById(...) is null
    Source File: chrome://mintrayr/content/messenger/messenger.js
    Line: 75
And, subsequently, the follow error when invoked:
3.  Error: TypeError: gMinTrayR.minimize is not a function
    Source File: chrome://messenger/content/messenger.xul
    Line: 1

The fix is simply to remember the id, whether it was already set or set in
the local code, and then to use the remembered value in searches.

This commit fixes the following issues:
- [MinimizeToTray is not work #142](https://github.com/nmaier/mintrayr/issues/142)
- [Console errors #139](https://github.com/nmaier/mintrayr/issues/139)
- [Neither F9 nor the menu entry have any effect in nightlies due to various errors #137](https://github.com/nmaier/mintrayr/issues/137)

As a consequence, it may also resolve some of the complaints of
dysfunction in recent reviews (as of Sunday, September 13, 2015):
https://addons.mozilla.org/en-US/thunderbird/addon/minimizetotray-revived/reviews/

_To test the fix locally,_
1. Get the files from github
2. At the command line, from within the directory, type `python build.py`
to create the .xpi file.
3. In Thunderbird, in the "Extensions" tab of the "Add-ons Manager" page
(accessible from the "Tools"->"Add-ons" menu), remove the existing
extension and restart Thunderbird.
4. In Thunderbird, again on the "Add-ons Manager" page, select the
"Tools for All Add-ons" drop-down near upper-right and choose "Install
Add-on From File...".
5. Select the .xpi that was created in step 2, confirm with "Install
Now", and restart Thunderbird.