### PR TITLE
Fix minimize-on-close for TB 52 on Linux

### DIFF
--- a/chrome/content/messenger/messenger.js
+++ b/chrome/content/messenger/messenger.js
@@ -41,6 +41,9 @@ addEventListener(
               event.stopPropagation();
               return false;
             }
+            if (event.type == "close") {
+              return true;
+            }
             // must be in sync with the original command
             return goQuitApplication();
           }
@@ -72,6 +75,7 @@ addEventListener(
           }
           ['titlebar-close'].forEach(hijackButton.bind(null, MinTrayRTryCloseWindow));
           ['titlebar-min'].forEach(hijackButton.bind(null, MinTrayRTryMinimizeWindow));
+          window.addEventListener("close", MinTrayRTryCloseWindow);
         })(this);
 
         this.cloneToMenu('MinTrayR_sep-top', [menu_NewPopup_id, "button-getAllNewMsg", "addressBook"], false);

--- a/install.rdf
+++ b/install.rdf
@@ -2,7 +2,7 @@
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
   <Description about="urn:mozilla:install-manifest">
     <em:id>mintrayr@tn123.ath.cx</em:id>
-    <em:version>1.3.2</em:version>
+    <em:version>1.3.2+tb52fix</em:version>
     <em:unpack>true</em:unpack>
     <em:multiprocessCompatible>true</em:multiprocessCompatible>
     <em:targetPlatform>WINNT_x86-msvc</em:targetPlatform>
@@ -18,6 +18,7 @@
     <em:contributor>Mook</em:contributor>
     <em:contributor>helix400</em:contributor>
     <em:contributor>Christoph Grimmer</em:contributor>
+    <em:contributor>rsjtdrjgfuzkfg</em:contributor>
 
     <em:homepageURL>https://tn123.org/mintrayr/</em:homepageURL>
     <em:optionsURL>chrome://mintrayr/content/prefs/prefs.xul</em:optionsURL>


### PR DESCRIPTION
This PR attempts to fix #178, #175 and #172 – but is untested on Windows and old versions of Thunderbird. I'd welcome some feedback on that, as I don't have the time to do proper testing right now.

I consider it very likely that we don't need to observe `titlebar-close` anymore after merging this. It does *not* call `goQuitApplication` but `window.close` – at least in the versions of TB I looked at, but I'm not comfortable doing the removal without any tests on Windows.

Also, the maintainer might want to use a different version number after merging; I merely added *something* in order to distinguish built xpis from official releases.